### PR TITLE
Mark vendor directory as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
-vendor/* linguist-generated=true
+go.mod linguist-generated=true
+go.sum linguist-generated=true merge=ours
+*.pb.go linguist-generated=true
+*.gen.go linguist-generated=true
+
+vendor/** linguist-generated=true


### PR DESCRIPTION
Mark vendored files as generated, to automatically collapse them from PRs & exclude them from statistics.

See: https://github.com/furiosa-ai/furiosa-device-plugin/pull/3#discussion_r1499006291