### PR TITLE
clean up dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/furiosa-ai/libfuriosa-kubernetes:buildbase as build
+FROM ghcr.io/furiosa-ai/libfuriosa-kubernetes:base as build
 
 # Build device-plugin binary
 WORKDIR /


### PR DESCRIPTION
### One line PR Description
from now on, we only have libfuriosa-kubernetes:base image without buildbase, this changes dockerfile manifest only refer to base image

### What type of PR is this?
- /kind cleanup
- 
### Special notes for reviewer
