### PR TITLE
Add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo.
 # Unless a later match takes precedence, below users will be requested for review when someone opens a pull request.
-*  @hoony9x-furiosa-ai @bg-furiosa @jongchanpark-furiosa
+*  @bg-furiosa


### PR DESCRIPTION
### One line PR Description
Add `CODEOWNERS`.

### What type of PR is this?
/kind cleanup

### Special notes for reviewer

Add `CODEOWNERS` to make it automatically assign specific users as reviewers.
- Please check [this docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).