### PR TITLE
Change `Dockerfile` to take base image as argument, and make it use distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,29 @@
-FROM registry.corp.furiosa.ai/furiosa/libfuriosa-kubernetes:latest as build
+ARG BASE_IMAGE=registry.corp.furiosa.ai/furiosa/libfuriosa-kubernetes:latest
+
+FROM $BASE_IMAGE as build
 
 # Build device-plugin binary
 WORKDIR /
 COPY . /
 RUN make build
 
-FROM registry.corp.furiosa.ai/furiosa/libfuriosa-kubernetes:latest
+FROM gcr.io/distroless/base-debian12:nonroot
 
 # Copy device plugin binary
 WORKDIR /
+
+# Below dynamic libraries are required.
+# $ ldd /main
+#     libfuriosa_smi.so => /lib/x86_64-linux-gnu/libfuriosa_smi.so (0x00007fffff4b0000)
+#     libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fffff2cf000)
+#     libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fffff2af000)
+#     libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fffff1d0000)
+#     /lib64/ld-linux-x86-64.so.2 (0x00007ffffffcc000)
+COPY --from=build /usr/lib/x86_64-linux-gnu/libfuriosa_smi.so /usr/lib/x86_64-linux-gnu/libfuriosa_smi.so
+COPY --from=build /usr/lib/x86_64-linux-gnu/libc.so.6 /usr/lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /usr/lib/x86_64-linux-gnu/libgcc_s.so.1 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /usr/lib/x86_64-linux-gnu/libm.so.6 /usr/lib/x86_64-linux-gnu/libm.so.6
+
 COPY --from=build /main /main
+
 CMD ["./main"]


### PR DESCRIPTION
### One line PR Description
`Dockerfile` will takes base image via `ARG`, and it will use distroless image too.

### What type of PR is this?
/kind devops

### Special notes for reviewer
- See [this slack thread](https://furiosa-ai.slack.com/archives/C06DMGWTULF/p1724386060028769) for more details.

> `furiosa-device-plugin` 과 `furiosa-metric-exporter` Repo 에는 변경 사항을 푸시해두었습니다.
> - [`furiosa-device-plugin` 변경사항](https://github.com/furiosa-ai/furiosa-device-plugin/commit/7a4b756b39058a28f5f6947c495bea756ddfbc60)
> - [`furiosa-metric-exporter` 변경사항](https://github.com/furiosa-ai/furiosa-metrics-exporter/commit/0bbdfe2a0a77ab8d7b2646aa35f0665b8c6acd77)
> 
> 특이사항으로 CGO 부분 때문인지 go build 결과물이 완전한 static binary 가 아닌데요, 이로 인해 일부 dynamic library 가 필요합니다.
> 해당 부분은 [여기](https://github.com/furiosa-ai/furiosa-metrics-exporter/commit/0bbdfe2a0a77ab8d7b2646aa35f0665b8c6acd77#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R15-R25)를 확인해주시면 되겠습니다.