### PR TITLE
Use `latest` tag for distroless image to solve permission issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /
 COPY . /
 RUN make build
 
-FROM gcr.io/distroless/base-debian12:nonroot
+FROM gcr.io/distroless/base-debian12:latest
 
 # Copy device plugin binary
 WORKDIR /


### PR DESCRIPTION
### One line PR Description
- ~~Add `cap_net_bind_service`, `cap_dac_override` caps to fix permission issue #35~~
- Use `latest` tag for distroless image to solve permission issue #35

### What type of PR is this?
/kind bug

### Special notes for reviewer
resolve: #35 
- ~~Linux caps `cap_net_bind_service`, `cap_dac_override` will be added during container image build process.~~
- ~~`NET_BIND_SERVICE` and `DAC_OVERRIDE` caps will be set in the `DaemonSet` YAML, container level `securityContext` section.~~
- Distroless image tag has been changed from `nonroot` to `latest` (root user).