### PR TITLE
fix helm chart node affinity key

### DIFF
--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -16,7 +16,7 @@ daemonSet:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: feature.node.kubernetes.io/pci-1ed2.present
+          - key: feature.node.kubernetes.io/pci-1200_1ed2.present
             operator: In
             values:
               - "true"


### PR DESCRIPTION
### One line PR Description
- the node affinity key of helm chart was following nvidias's nfd custom rule, this pr fix it to follow default nfd rule


### What type of PR is this?
- /kind bug

### Special notes for reviewer
