### PR TITLE
Set `furiosa-smi-go` as `v0.1.1` and `libfuriosa-kubernetes` as `v0.1.33`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.23.2
 require (
 	github.com/bradfitz/iter v0.0.0-20191230175014-e8f45d346db8
 	github.com/fsnotify/fsnotify v1.8.0
-	github.com/furiosa-ai/furiosa-smi-go v0.1.1-0.20241106050232-6ac0a9bd52a7
-	github.com/furiosa-ai/libfuriosa-kubernetes v0.1.33-0.20241106051032-cc14aa1ecd3e
+	github.com/furiosa-ai/furiosa-smi-go v0.1.1
+	github.com/furiosa-ai/libfuriosa-kubernetes v0.1.33
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -106,10 +106,10 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/furiosa-ai/furiosa-smi-go v0.1.1-0.20241106050232-6ac0a9bd52a7 h1:GRQgeeKfdeeU4HoNHD3S1y6smNviH1d0MYXbAOithVs=
-github.com/furiosa-ai/furiosa-smi-go v0.1.1-0.20241106050232-6ac0a9bd52a7/go.mod h1:tfYdEtnlD4Hoyv3K5O/ZcI4iBbdo0jKvqyKIsSx65DA=
-github.com/furiosa-ai/libfuriosa-kubernetes v0.1.33-0.20241106051032-cc14aa1ecd3e h1:1jC1DlbPs7oh22j9beqBOvM0KZxCWsO95kjQhdTZqdM=
-github.com/furiosa-ai/libfuriosa-kubernetes v0.1.33-0.20241106051032-cc14aa1ecd3e/go.mod h1:KFeoknfRQoo+fH8l92rPhEmy6EysWCVmvoo/EaDtL3w=
+github.com/furiosa-ai/furiosa-smi-go v0.1.1 h1:e4bI7pGKsG4Y3ctEZRjF/V8I8rknCR5/xNx5k7zN35w=
+github.com/furiosa-ai/furiosa-smi-go v0.1.1/go.mod h1:tfYdEtnlD4Hoyv3K5O/ZcI4iBbdo0jKvqyKIsSx65DA=
+github.com/furiosa-ai/libfuriosa-kubernetes v0.1.33 h1:DBXEs4FUU+MxznLHq3VAO1IqgYLwrikl813oLPRob4M=
+github.com/furiosa-ai/libfuriosa-kubernetes v0.1.33/go.mod h1:KFeoknfRQoo+fH8l92rPhEmy6EysWCVmvoo/EaDtL3w=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -141,11 +141,11 @@ github.com/felixge/httpsnoop
 ## explicit; go 1.17
 github.com/fsnotify/fsnotify
 github.com/fsnotify/fsnotify/internal
-# github.com/furiosa-ai/furiosa-smi-go v0.1.1-0.20241106050232-6ac0a9bd52a7
+# github.com/furiosa-ai/furiosa-smi-go v0.1.1
 ## explicit; go 1.23.2
 github.com/furiosa-ai/furiosa-smi-go/pkg/smi
 github.com/furiosa-ai/furiosa-smi-go/pkg/smi/binding
-# github.com/furiosa-ai/libfuriosa-kubernetes v0.1.33-0.20241106051032-cc14aa1ecd3e
+# github.com/furiosa-ai/libfuriosa-kubernetes v0.1.33
 ## explicit; go 1.23.2
 github.com/furiosa-ai/libfuriosa-kubernetes/pkg/e2e
 github.com/furiosa-ai/libfuriosa-kubernetes/pkg/manifest


### PR DESCRIPTION
### One line PR Description
- resolve: https://github.com/furiosa-ai/cloud-native-toolkit/issues/23

### What type of PR is this?
/kind chore

### Special notes for reviewer
