### PR TITLE
Revise unit tests to improve readability

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,9 +1,10 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetConfigFromFile(t *testing.T) {
@@ -91,13 +92,15 @@ func TestGetConfigFromFile(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		actualConf, actualErr := getConfigFromFile(absPath(tc.configPath))
-		if tc.expectedError {
-			assert.NotNilf(t, actualErr, tc.description)
-		} else {
-			assert.Nilf(t, actualErr, tc.description)
-			assert.Equalf(t, tc.expectedResult, actualConf, tc.description)
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			actualConf, actualErr := getConfigFromFile(absPath(tc.configPath))
+			if tc.expectedError {
+				assert.NotNilf(t, actualErr, tc.description)
+			} else {
+				assert.Nilf(t, actualErr, tc.description)
+				assert.Equalf(t, tc.expectedResult, actualConf, tc.description)
+			}
+		})
 	}
 }
 
@@ -181,8 +184,10 @@ func TestIsEqualConfig(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		actual := isEqualConfig(tc.a, tc.b)
-		assert.Equalf(t, tc.expected, actual, tc.description)
+		t.Run(tc.description, func(t *testing.T) {
+			actual := isEqualConfig(tc.a, tc.b)
+			assert.Equalf(t, tc.expected, actual, tc.description)
+		})
 	}
 }
 

--- a/internal/device_manager/exclusive_device_test.go
+++ b/internal/device_manager/exclusive_device_test.go
@@ -1,11 +1,11 @@
 package device_manager
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/furiosa-ai/furiosa-smi-go/pkg/smi"
 	"github.com/furiosa-ai/libfuriosa-kubernetes/pkg/npu_allocator"
+	"github.com/stretchr/testify/assert"
 	devicePluginAPIv1Beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
@@ -23,16 +23,13 @@ func TestDeviceID(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
-		actualResult := exclusiveDev.DeviceID()
-		if actualResult != tc.expectedResult {
-			t.Errorf("expectedResult %s but got %s", tc.expectedResult, actualResult)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
+			assert.NoError(t, err)
+
+			actualResult := exclusiveDev.DeviceID()
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
 	}
 }
 
@@ -55,17 +52,13 @@ func TestPCIBusID(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
+			assert.NoError(t, err)
 
-		actualResult := exclusiveDev.PCIBusID()
-		if actualResult != tc.expectedResult {
-			t.Errorf("expectedResult %s but got %s", tc.expectedResult, actualResult)
-			continue
-		}
+			actualResult := exclusiveDev.PCIBusID()
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
 	}
 }
 
@@ -91,16 +84,13 @@ func TestNUMANode(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
+			assert.NoError(t, err)
 
-		actualResult := exclusiveDev.NUMANode()
-		if actualResult != tc.expectedResult {
-			t.Errorf("expectedResult %d but got %d", tc.expectedResult, actualResult)
-		}
+			actualResult := exclusiveDev.NUMANode()
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
 	}
 }
 
@@ -160,16 +150,13 @@ func TestDeviceSpecs(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
+			assert.NoError(t, err)
 
-		actualResult := exclusiveDev.DeviceSpecs()
-		if !reflect.DeepEqual(actualResult, tc.expectedResult) {
-			t.Errorf("expectedResult %v but got %v", tc.expectedResult, actualResult)
-		}
+			actualResult := exclusiveDev.DeviceSpecs()
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
 	}
 }
 
@@ -196,21 +183,15 @@ func TestIsHealthy(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, tc.isDisabled)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, tc.isDisabled)
+			assert.NoError(t, err)
 
-		actualResult, err := exclusiveDev.IsHealthy()
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+			actualResult, err := exclusiveDev.IsHealthy()
+			assert.NoError(t, err)
 
-		if actualResult != tc.expectedResult {
-			t.Errorf("expectedResult %t but got %t", tc.expectedResult, actualResult)
-		}
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
 	}
 }
 
@@ -269,16 +250,13 @@ func TestMounts(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
+			assert.NoError(t, err)
 
-		actualResult := exclusiveDev.Mounts()
-		if !reflect.DeepEqual(actualResult, tc.expectedResult) {
-			t.Errorf("expectedResult %v but got %v", tc.expectedResult, actualResult)
-		}
+			actualResult := exclusiveDev.Mounts()
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
 	}
 }
 
@@ -296,16 +274,13 @@ func TestID(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
-		actualResult := exclusiveDev.ID()
-		if actualResult != tc.expectedResult {
-			t.Errorf("expectedResult %s but got %s", tc.expectedResult, actualResult)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
+			assert.NoError(t, err)
+
+			actualResult := exclusiveDev.ID()
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
 	}
 }
 
@@ -323,17 +298,13 @@ func TestTopologyHintKey(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			exclusiveDev, err := NewExclusiveDevice(tc.mockDevice, false)
+			assert.NoError(t, err)
 
-		actualResult := exclusiveDev.TopologyHintKey()
-		if actualResult != tc.expectedResult {
-			t.Errorf("expectedResult %s but got %s", tc.expectedResult, actualResult)
-			continue
-		}
+			actualResult := exclusiveDev.TopologyHintKey()
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
 	}
 }
 
@@ -358,22 +329,15 @@ func TestEqual(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		source, err := NewExclusiveDevice(tc.mockSourceDevice, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			source, err := NewExclusiveDevice(tc.mockSourceDevice, false)
+			assert.NoError(t, err)
 
-		target, err := NewExclusiveDevice(tc.mockTargetDevice, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+			target, err := NewExclusiveDevice(tc.mockTargetDevice, false)
+			assert.NoError(t, err)
 
-		actual := source.Equal(target)
-		if actual != tc.expected {
-			t.Errorf("expectedResult %v but got %v", tc.expected, actual)
-			continue
-		}
+			actual := source.Equal(target)
+			assert.Equal(t, tc.expected, actual)
+		})
 	}
 }

--- a/internal/device_manager/partitioned_device_rngd_test.go
+++ b/internal/device_manager/partitioned_device_rngd_test.go
@@ -2,7 +2,6 @@ package device_manager
 
 import (
 	"fmt"
-	"reflect"
 	"slices"
 	"testing"
 
@@ -170,26 +169,20 @@ func TestDeviceIDs_RNGD_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		if len(partitionedDevices) != len(tc.expectedResults) {
-			t.Errorf("length of expectedResults and partitioned devices are not equal for strategy %s: expected: %d, got: %d", tc.strategy, len(tc.expectedResults), len(partitionedDevices))
-			continue
-		}
+			assert.Lenf(t, partitionedDevices, len(tc.expectedResults), "length of expectedResults and partitioned devices are not equal for strategy %s: expected: %d, got: %d", tc.strategy, len(tc.expectedResults), len(partitionedDevices))
 
-		for i, device := range partitionedDevices {
-			expectedDeviceId := tc.expectedResults[i]
-			actualDeviceId := device.DeviceID()
-			if expectedDeviceId != actualDeviceId {
-				t.Errorf("expected Device ID %s, got %s", expectedDeviceId, actualDeviceId)
-				continue
+			for i, device := range partitionedDevices {
+				expectedDeviceId := tc.expectedResults[i]
+				actualDeviceId := device.DeviceID()
+
+				assert.Equal(t, expectedDeviceId, actualDeviceId)
 			}
-		}
+		})
 	}
 }
 
@@ -221,21 +214,17 @@ func TestPCIBusIDs_RNGD_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		expectedPCIBusID := tc.expectedResult
-		for _, device := range partitionedDevices {
-			actualPCIBusID := device.PCIBusID()
-			if expectedPCIBusID != actualPCIBusID {
-				t.Errorf("expected PCIBusID %s, got %s", expectedPCIBusID, actualPCIBusID)
-				continue
+			expectedPCIBusID := tc.expectedResult
+			for _, device := range partitionedDevices {
+				actualPCIBusID := device.PCIBusID()
+				assert.Equal(t, expectedPCIBusID, actualPCIBusID)
 			}
-		}
+		})
 	}
 }
 
@@ -267,21 +256,17 @@ func TestNUMANode_RNGD_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, true)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, true)
+			assert.NoError(t, err)
 
-		expectedNUMANode := tc.expectedResult
-		for _, device := range partitionedDevices {
-			actualNUMANode := device.NUMANode()
-			if expectedNUMANode != actualNUMANode {
-				t.Errorf("expected NUMA node %d, got %d", expectedNUMANode, actualNUMANode)
-				continue
+			expectedNUMANode := tc.expectedResult
+			for _, device := range partitionedDevices {
+				actualNUMANode := device.NUMANode()
+				assert.Equal(t, expectedNUMANode, actualNUMANode)
 			}
-		}
+		})
 	}
 }
 
@@ -630,23 +615,18 @@ func TestDeviceSpecs_RNGD_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		if len(partitionedDevices) != len(tc.expectedResultCandidates) {
-			t.Errorf("%s: expected %d partitioned devices, got %d", tc.description, len(tc.expectedResultCandidates), len(partitionedDevices))
-		}
+			assert.Len(t, partitionedDevices, len(tc.expectedResultCandidates))
 
-		for i, device := range partitionedDevices {
-			actualResult := device.DeviceSpecs()
-			if !reflect.DeepEqual(actualResult, tc.expectedResultCandidates[i]) {
-				t.Errorf("%s: expected %v, got %v", tc.description, tc.expectedResultCandidates[i], actualResult)
+			for i, device := range partitionedDevices {
+				actualResult := device.DeviceSpecs()
+				assert.Equal(t, tc.expectedResultCandidates[i], actualResult)
 			}
-		}
+		})
 	}
 }
 
@@ -675,24 +655,18 @@ func TestIsHealthy_RNGD_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, tc.isDisabled)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, tc.isDisabled)
+			assert.NoError(t, err)
 
-		for _, device := range partitionedDevices {
-			actualResult, err := device.IsHealthy()
-			if err != nil {
-				t.Errorf("%s: unexpected error: %v", tc.description, err)
-				continue
-			}
+			for _, device := range partitionedDevices {
+				actualResult, err := device.IsHealthy()
+				assert.NoError(t, err)
 
-			if actualResult != tc.expectedResults {
-				t.Errorf("expectedResults %v but got %v", tc.expectedResults, actualResult)
+				assert.Equal(t, tc.expectedResults, actualResult)
 			}
-		}
+		})
 	}
 }
 
@@ -726,19 +700,16 @@ func TestMounts_RNGD_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		for _, device := range partitionedDevices {
-			actualResults := device.Mounts()
-			if !reflect.DeepEqual(actualResults, tc.expectedResults) {
-				t.Errorf("expectedResults %v but got %v", tc.expectedResults, actualResults)
+			for _, device := range partitionedDevices {
+				actualResults := device.Mounts()
+				assert.Equal(t, tc.expectedResults, actualResults)
 			}
-		}
+		})
 	}
 }
 
@@ -790,26 +761,20 @@ func TestID_RNGD_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		if len(partitionedDevices) != len(tc.expectedResults) {
-			t.Errorf("length of expectedResults and partitioned devices are not equal for strategy %s: expected: %d, got: %d", tc.strategy, len(tc.expectedResults), len(partitionedDevices))
-			continue
-		}
+			assert.Lenf(t, partitionedDevices, len(tc.expectedResults), "length of expectedResults and partitioned devices are not equal for strategy %s: expected: %d, got: %d", tc.strategy, len(tc.expectedResults), len(partitionedDevices))
 
-		for i, device := range partitionedDevices {
-			expectedId := tc.expectedResults[i]
-			actualId := device.ID()
-			if expectedId != actualId {
-				t.Errorf("expected ID %s, got %s", expectedId, actualId)
-				continue
+			for i, device := range partitionedDevices {
+				expectedId := tc.expectedResults[i]
+				actualId := device.ID()
+
+				assert.Equal(t, expectedId, actualId)
 			}
-		}
+		})
 	}
 }
 
@@ -841,20 +806,17 @@ func TestTopologyHintKey_RNGD_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		for _, device := range partitionedDevices {
-			actualResult := device.TopologyHintKey()
-			if actualResult != tc.expectedResult {
-				t.Errorf("expectedResults %s, got %s", tc.expectedResult, actualResult)
-				continue
+			for _, device := range partitionedDevices {
+				actualResult := device.TopologyHintKey()
+
+				assert.Equal(t, tc.expectedResult, actualResult)
 			}
-		}
+		})
 	}
 }
 
@@ -883,34 +845,25 @@ func TestEqual_RNGD_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
 
-		sourcePartitionedDevices, err := NewPartitionedDevices(tc.mockSourceDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+			sourcePartitionedDevices, err := NewPartitionedDevices(tc.mockSourceDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		targetPartitionedDevices, err := NewPartitionedDevices(tc.mockTargetDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+			targetPartitionedDevices, err := NewPartitionedDevices(tc.mockTargetDevice, numOfCoresPerPartition, totalCoresOfRNGD/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		if len(sourcePartitionedDevices) != len(targetPartitionedDevices) {
-			t.Errorf("length of sourcePartitionedDevices and targetPartitionedDevices is different!")
-			continue
-		}
+			assert.Len(t, sourcePartitionedDevices, len(targetPartitionedDevices))
 
-		for i := range sourcePartitionedDevices {
-			sourceDevice := sourcePartitionedDevices[i]
-			targetDevice := targetPartitionedDevices[i]
+			for i := range sourcePartitionedDevices {
+				sourceDevice := sourcePartitionedDevices[i]
+				targetDevice := targetPartitionedDevices[i]
 
-			actualResult := sourceDevice.Equal(targetDevice)
-			if actualResult != tc.expected {
-				t.Errorf("expected: %v, got: %v", tc.expected, actualResult)
-				continue
+				actualResult := sourceDevice.Equal(targetDevice)
+
+				assert.Equal(t, tc.expected, actualResult)
 			}
-		}
+		})
 	}
 }

--- a/internal/device_manager/partitioned_device_warboy_test.go
+++ b/internal/device_manager/partitioned_device_warboy_test.go
@@ -2,7 +2,6 @@ package device_manager
 
 import (
 	"fmt"
-	"reflect"
 	"slices"
 	"testing"
 
@@ -131,26 +130,20 @@ func TestDeviceIDs_Warboy_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		if len(partitionedDevices) != len(tc.expectedResults) {
-			t.Errorf("length of expectedResults and partitioned devices are not equal for strategy %s: expected: %d, got: %d", tc.strategy, len(tc.expectedResults), len(partitionedDevices))
-			continue
-		}
+			assert.Lenf(t, partitionedDevices, len(tc.expectedResults), "length of expectedResults and partitioned devices are not equal for strategy %s: expected: %d, got: %d", tc.strategy, len(tc.expectedResults), len(partitionedDevices))
 
-		for i, device := range partitionedDevices {
-			expectedDeviceId := tc.expectedResults[i]
-			actualDeviceId := device.DeviceID()
-			if expectedDeviceId != actualDeviceId {
-				t.Errorf("expected Device ID %s, got %s", expectedDeviceId, actualDeviceId)
-				continue
+			for i, device := range partitionedDevices {
+				expectedDeviceId := tc.expectedResults[i]
+				actualDeviceId := device.DeviceID()
+
+				assert.Equal(t, expectedDeviceId, actualDeviceId)
 			}
-		}
+		})
 	}
 }
 
@@ -182,21 +175,18 @@ func TestPCIBusIDs_Warboy_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		expectedPCIBusID := tc.expectedResult
-		for _, device := range partitionedDevices {
-			actualPCIBusID := device.PCIBusID()
-			if expectedPCIBusID != actualPCIBusID {
-				t.Errorf("expected PCIBusID %s, got %s", expectedPCIBusID, actualPCIBusID)
-				continue
+			expectedPCIBusID := tc.expectedResult
+			for _, device := range partitionedDevices {
+				actualPCIBusID := device.PCIBusID()
+
+				assert.Equal(t, expectedPCIBusID, actualPCIBusID)
 			}
-		}
+		})
 	}
 }
 
@@ -228,21 +218,18 @@ func TestNUMANode_Warboy_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("unexpected error %t", err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		expectedNUMANode := tc.expectedResult
-		for _, device := range partitionedDevices {
-			actualNUMANode := device.NUMANode()
-			if expectedNUMANode != actualNUMANode {
-				t.Errorf("expected NUMA node %d, got %d", expectedNUMANode, actualNUMANode)
-				continue
+			expectedNUMANode := tc.expectedResult
+			for _, device := range partitionedDevices {
+				actualNUMANode := device.NUMANode()
+
+				assert.Equal(t, expectedNUMANode, actualNUMANode)
 			}
-		}
+		})
 	}
 }
 
@@ -368,23 +355,19 @@ func TestDeviceSpecs_Warboy_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		if len(partitionedDevices) != len(tc.expectedResultCandidates) {
-			t.Errorf("%s: expected %d partitioned devices, got %d", tc.description, len(tc.expectedResultCandidates), len(partitionedDevices))
-		}
+			assert.Lenf(t, partitionedDevices, len(tc.expectedResultCandidates), "%s: expected %d partitioned devices, got %d", tc.description, len(tc.expectedResultCandidates), len(partitionedDevices))
 
-		for i, device := range partitionedDevices {
-			actualResult := device.DeviceSpecs()
-			if !reflect.DeepEqual(actualResult, tc.expectedResultCandidates[i]) {
-				t.Errorf("%s: expected %v, got %v", tc.description, tc.expectedResultCandidates[i], actualResult)
+			for i, device := range partitionedDevices {
+				actualResult := device.DeviceSpecs()
+
+				assert.Equal(t, tc.expectedResultCandidates[i], actualResult)
 			}
-		}
+		})
 	}
 }
 
@@ -413,24 +396,18 @@ func TestIsHealthy_Warboy_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, tc.isDisabled)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, tc.isDisabled)
+			assert.NoError(t, err)
 
-		for _, device := range partitionedDevices {
-			actualResult, err := device.IsHealthy()
-			if err != nil {
-				t.Errorf("%s: unexpected error: %v", tc.description, err)
-				continue
-			}
+			for _, device := range partitionedDevices {
+				actualResult, err := device.IsHealthy()
+				assert.NoError(t, err)
 
-			if actualResult != tc.expectedResults {
-				t.Errorf("expectedResults %v but got %v", tc.expectedResults, actualResult)
+				assert.Equal(t, tc.expectedResults, actualResult)
 			}
-		}
+		})
 	}
 }
 
@@ -464,26 +441,20 @@ func TestID_Warboy_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		if len(partitionedDevices) != len(tc.expectedResults) {
-			t.Errorf("length of expectedResults and partitioned devices are not equal for strategy %s: expected: %d, got: %d", tc.strategy, len(tc.expectedResults), len(partitionedDevices))
-			continue
-		}
+			assert.Lenf(t, partitionedDevices, len(tc.expectedResults), "length of expectedResults and partitioned devices are not equal for strategy %s: expected: %d, got: %d", tc.strategy, len(tc.expectedResults), len(partitionedDevices))
 
-		for i, device := range partitionedDevices {
-			expectedId := tc.expectedResults[i]
-			actualId := device.ID()
-			if expectedId != actualId {
-				t.Errorf("expected ID %s, got %s", expectedId, actualId)
-				continue
+			for i, device := range partitionedDevices {
+				expectedId := tc.expectedResults[i]
+				actualId := device.ID()
+
+				assert.Equal(t, expectedId, actualId)
 			}
-		}
+		})
 	}
 }
 
@@ -515,20 +486,17 @@ func TestTopologyHintKey_Warboy_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
-		partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
+			partitionedDevices, err := NewPartitionedDevices(tc.mockDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		for _, device := range partitionedDevices {
-			actualResult := device.TopologyHintKey()
-			if actualResult != tc.expectedResult {
-				t.Errorf("expectedResults %s, got %s", tc.expectedResult, actualResult)
-				continue
+			for _, device := range partitionedDevices {
+				actualResult := device.TopologyHintKey()
+
+				assert.Equal(t, tc.expectedResult, actualResult)
 			}
-		}
+		})
 	}
 }
 
@@ -557,34 +525,25 @@ func TestEqual_Warboy_PartitionedDevice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		numOfCoresPerPartition := tc.strategy.CoreSize()
+		t.Run(tc.description, func(t *testing.T) {
+			numOfCoresPerPartition := tc.strategy.CoreSize()
 
-		sourcePartitionedDevices, err := NewPartitionedDevices(tc.mockSourceDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+			sourcePartitionedDevices, err := NewPartitionedDevices(tc.mockSourceDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		targetPartitionedDevices, err := NewPartitionedDevices(tc.mockTargetDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tc.description, err)
-			continue
-		}
+			targetPartitionedDevices, err := NewPartitionedDevices(tc.mockTargetDevice, numOfCoresPerPartition, totalCoresOfWarboy/numOfCoresPerPartition, false)
+			assert.NoError(t, err)
 
-		if len(sourcePartitionedDevices) != len(targetPartitionedDevices) {
-			t.Errorf("length of sourcePartitionedDevices and targetPartitionedDevices is different!")
-			continue
-		}
+			assert.Len(t, sourcePartitionedDevices, len(targetPartitionedDevices))
 
-		for i := range sourcePartitionedDevices {
-			sourceDevice := sourcePartitionedDevices[i]
-			targetDevice := targetPartitionedDevices[i]
+			for i := range sourcePartitionedDevices {
+				sourceDevice := sourcePartitionedDevices[i]
+				targetDevice := targetPartitionedDevices[i]
 
-			actualResult := sourceDevice.Equal(targetDevice)
-			if actualResult != tc.expected {
-				t.Errorf("expected: %v, got: %v", tc.expected, actualResult)
-				continue
+				actualResult := sourceDevice.Equal(targetDevice)
+
+				assert.Equal(t, tc.expected, actualResult)
 			}
-		}
+		})
 	}
 }

--- a/internal/device_manager/resource_name_test.go
+++ b/internal/device_manager/resource_name_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/furiosa-ai/furiosa-smi-go/pkg/smi"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/furiosa-ai/furiosa-device-plugin/internal/config"
 )
@@ -42,10 +43,10 @@ func TestBuildDomainName(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		actual := buildDomainName(tc.strategy)
-		if actual != tc.expected {
-			t.Errorf("expectedResult %s but got %s", tc.expected, actual)
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			actual := buildDomainName(tc.strategy)
+			assert.Equal(t, tc.expected, actual)
+		})
 	}
 }
 
@@ -130,15 +131,16 @@ func TestBuildFullEndpoint(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		actualResult, actualErr := buildFullEndpoint(tc.arch, tc.strategy)
-		if actualErr != nil != tc.expectError {
-			t.Errorf("unexpected error %t", actualErr)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			actualResult, actualErr := buildFullEndpoint(tc.arch, tc.strategy)
+			if tc.expectError {
+				assert.Error(t, actualErr)
+			} else {
+				assert.NoError(t, actualErr)
+			}
 
-		if actualResult != tc.expectedResult {
-			t.Errorf("expectedResult %s but got %s", tc.expectedResult, actualResult)
-		}
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
 	}
 }
 
@@ -223,14 +225,15 @@ func TestBuildAndValidateFullResourceEndpointName(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		actualResult, actualErr := buildAndValidateFullResourceEndpointName(tc.arch, tc.strategy)
-		if actualErr != nil != tc.expectError {
-			t.Errorf("unexpected error %t", actualErr)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			actualResult, actualErr := buildAndValidateFullResourceEndpointName(tc.arch, tc.strategy)
+			if tc.expectError {
+				assert.Error(t, actualErr)
+			} else {
+				assert.NoError(t, actualErr)
+			}
 
-		if actualResult != tc.expectedResult {
-			t.Errorf("expectedResult %s but got %s", tc.expectedResult, actualResult)
-		}
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
 	}
 }

--- a/internal/device_manager/utils_test.go
+++ b/internal/device_manager/utils_test.go
@@ -2,6 +2,8 @@ package device_manager
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseBusIDfromBDF(t *testing.T) {
@@ -32,15 +34,15 @@ func TestParseBusIDfromBDF(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		actualResult, actualErr := parseBusIDfromBDF(tc.bdf)
-		if actualErr != nil != tc.expectedError {
-			t.Errorf("got unexpected error %t", actualErr)
-			continue
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			actualResult, actualErr := parseBusIDfromBDF(tc.bdf)
+			if tc.expectedError {
+				assert.Error(t, actualErr)
+			} else {
+				assert.NoError(t, actualErr)
+			}
 
-		if actualResult != tc.expectedResult {
-			t.Errorf("expectedResult %s but got %s", tc.expectedResult, actualResult)
-			continue
-		}
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
 	}
 }

--- a/internal/plugin_cmd/cmd_test.go
+++ b/internal/plugin_cmd/cmd_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -53,16 +55,11 @@ func TestDevicePluginCommand(t *testing.T) {
 
 		err := cmd.Execute()
 		if err != nil || tc.expectedError != nil {
-			if strings.TrimSpace(safeError(err)) != strings.TrimSpace(safeError(tc.expectedError)) {
-				t.Errorf("expected %t but got actual %t", err, tc.expectedError)
-			}
+			assert.Equal(t, strings.TrimSpace(safeError(err)), strings.TrimSpace(safeError(tc.expectedError)))
 		}
 
 		output := buf.String()
 
-		if strings.TrimSpace(output) != strings.TrimSpace(tc.expectedResult) {
-			t.Errorf("actual result does not match to expected result")
-			println("actual: ", output)
-		}
+		assert.Equal(t, strings.TrimSpace(tc.expectedResult), strings.TrimSpace(output))
 	}
 }


### PR DESCRIPTION
### One line PR Description
Revise unit tests to improve readability.
- Use sub-tests like `t.Run(...)`.
- Use `assert` to reduce redundant codes.

### What type of PR is this?
/kind cleanup

### Special notes for reviewer
