### PR TITLE
use defaut config if `/etc/config/config.yaml` does not exist

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,19 @@ type ConfigChangeEvent struct {
 	Detail   string
 }
 
-func GetConfigWithWatcher(configPath string, confUpdateChan chan *ConfigChangeEvent) (*Config, error) {
+// LoadConfigOrGetDefault attempts to load config from GlobalConfigMountPath if the file exists,
+// otherwise it returns the default config.
+func LoadConfigOrGetDefault() (*Config, chan *ConfigChangeEvent, error) {
+	confUpdateChan := make(chan *ConfigChangeEvent, 1)
+	if _, statErr := os.Stat(GlobalConfigMountPath); statErr == nil {
+		conf, err := getConfigWithWatcher(GlobalConfigMountPath, confUpdateChan)
+		return conf, confUpdateChan, err
+	}
+
+	return getDefaultConfig(), confUpdateChan, nil
+}
+
+func getConfigWithWatcher(configPath string, confUpdateChan chan *ConfigChangeEvent) (*Config, error) {
 	conf, err := getConfigFromFile(configPath)
 	if err != nil {
 		return nil, err

--- a/internal/plugin_cmd/cmd.go
+++ b/internal/plugin_cmd/cmd.go
@@ -61,10 +61,10 @@ func start(ctx context.Context) error {
 	//grpc server panic listener
 	grpcErrChan := make(chan error, 1)
 
-	confUpdateChan := make(chan *config.ConfigChangeEvent, 1)
-	conf, err := config.GetConfigWithWatcher(config.GlobalConfigMountPath, confUpdateChan)
+	// load config or default
+	conf, confUpdateChan, err := config.LoadConfigOrGetDefault()
 	if err != nil {
-		logger.Err(err).Msg("couldn't parse configuration")
+		logger.Err(err).Msg("couldn't load configuration")
 		return err
 	}
 


### PR DESCRIPTION
### One line PR Description
[//]: # (If this PR references other issue, please paste that link into below `{ISSUE_LINK_HERE}` section and uncomment it.)
[//]: # (- resolve: {ISSUE_LINK_HERE})
This change allows user to deploy device plugin with out configuration configMap, in that case default config will be applied.

### What type of PR is this?
[//]: # (Please add same label in your PR too.)
- /kind cleanup

<!--
/kind bug
/kind cleanup
/kind feature
/kind chore
/kind devops
/kind documentation
-->

### Special notes for reviewer
