### PR TITLE
Support multi-arch container image build (amd64 + arm64)

### DIFF
--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -5,13 +5,24 @@ on:
     tags:
       - '*'
 
+env:
+  REGISTRY_URL: "asia-northeast3-docker.pkg.dev"
+  REGISTRY_PATH: "next-gen-infra/furiosa-ai"
+  IMAGE_NAME: "furiosa-device-plugin"
+
 jobs:
-  public_build_push:
-    runs-on: ubuntu-24.04
-    env:
-      REGISTRY_URL: "asia-northeast3-docker.pkg.dev"
-      REGISTRY_PATH: "next-gen-infra/furiosa-ai"
-      IMAGE_NAME: "furiosa-device-plugin"
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
 
@@ -24,10 +35,56 @@ jobs:
           username: "_json_key"
           password: ${{ secrets.GAR_JSON_KEY }}
 
-      - name: Build and publish PR image with Tag
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
-          push: true
-          tags: '${{ env.REGISTRY_URL }}/${{ env.REGISTRY_PATH }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}'
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY_URL }}/${{ env.REGISTRY_PATH }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-24.04
+    needs: [build]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: public registry login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: "_json_key"
+          password: ${{ secrets.GAR_JSON_KEY }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_PATH }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} \
+            $(printf '${{ env.REGISTRY_URL }}/${{ env.REGISTRY_PATH }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_PATH }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/libfuriosa-kubernetes:v2026.1.1
+ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/libfuriosa-kubernetes:38c0ce0-test
 
 FROM $BASE_IMAGE as build
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/libfuriosa-kubernetes:38c0ce0-test
+ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/libfuriosa-kubernetes:v2026.1.1
 
 FROM $BASE_IMAGE as build
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,34 @@
 ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/libfuriosa-kubernetes:v2026.1.1
 
 FROM $BASE_IMAGE as build
+ARG TARGETARCH
 
 # Build device-plugin binary
 WORKDIR /
 COPY . /
 RUN make build
 
+# Stage arch-specific runtime libs under their final path so the distroless
+# stage (no shell) can copy them verbatim. Below dynamic libraries are required
+# due to `furiosa-smi` and Rust dependencies.
+RUN set -eux; \
+    case "$TARGETARCH" in \
+        amd64) libDir='x86_64-linux-gnu' ;; \
+        arm64) libDir='aarch64-linux-gnu' ;; \
+        *) echo >&2 "unsupported architecture: $TARGETARCH"; exit 1 ;; \
+    esac; \
+    mkdir -p /staging/usr/lib/$libDir; \
+    cp /usr/lib/$libDir/libfuriosa_smi.so /staging/usr/lib/$libDir/; \
+    cp /usr/lib/$libDir/libgcc_s.so.1     /staging/usr/lib/$libDir/
+
 FROM gcr.io/distroless/base-debian12:latest
 
 # Copy device plugin binary
 WORKDIR /
 
-# Below dynamic libraries are required due to `furiosa-smi` and Rust dependencies.
-COPY --from=build /usr/lib/x86_64-linux-gnu/libfuriosa_smi.so /usr/lib/x86_64-linux-gnu/libfuriosa_smi.so
-COPY --from=build /usr/lib/x86_64-linux-gnu/libgcc_s.so.1 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+# Arch-specific dynamic libs (libfuriosa_smi + Rust libgcc_s), landed in the
+# running arch's multiarch dir via the staging tree built above.
+COPY --from=build /staging/ /
 
 COPY --from=build /main /main
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN make build
 # Stage arch-specific runtime libs under their final path so the distroless
 # stage (no shell) can copy them verbatim. Below dynamic libraries are required
 # due to `furiosa-smi` and Rust dependencies.
-RUN set -eux; \
+RUN set -e; \
     case "$TARGETARCH" in \
         amd64) libDir='x86_64-linux-gnu' ;; \
         arm64) libDir='aarch64-linux-gnu' ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,11 @@ RUN set -e; \
         *) echo >&2 "unsupported architecture: $TARGETARCH"; exit 1 ;; \
     esac; \
     mkdir -p /staging/usr/lib/$libDir; \
-    cp /usr/lib/$libDir/libfuriosa_smi.so /staging/usr/lib/$libDir/; \
-    cp /usr/lib/$libDir/libgcc_s.so.1     /staging/usr/lib/$libDir/
+    cp /usr/lib/$libDir/libfuriosa_smi.so /staging/usr/lib/$libDir/libfuriosa_smi.so; \
+    cp /usr/lib/$libDir/libgcc_s.so.1     /staging/usr/lib/$libDir/libgcc_s.so.1
 
 FROM gcr.io/distroless/base-debian12:latest
 
-# Copy device plugin binary
 WORKDIR /
 
 # Arch-specific dynamic libs (libfuriosa_smi + Rust libgcc_s), landed in the


### PR DESCRIPTION
### One line PR Description
- resolve: CN-276

Build and publish the `furiosa-device-plugin` image for both `linux/amd64` and `linux/arm64`.

### What type of PR is this?
/kind devops

### Special notes for reviewer
